### PR TITLE
Fix amulet of reincarnation stopping all game ends

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -1172,38 +1172,39 @@ int how;
             g.context.botl = 1;
         }
     }
-    if (Lifesaved && uamul && uamul->otyp == AMULET_OF_REINCARNATION) {
+    if (Lifesaved && how <= GENOCIDED) {
         pline("But wait...");
-        makeknown(AMULET_OF_REINCARNATION);
-        Your("medallion %s!", !Hallucination ? "begins to blaze with energy" : "feels hot");
-        You("are given another chance at life!");
-        if (uamul)
-            useup(uamul);
-        HUnchanging = 0L;
-        polyself(3);
-        savelife(how);
-        HUnchanging |= FROMOUTSIDE;
-        livelog_printf(LL_LIFESAVE, "was reincarnated as a %s",
-            g.youmonst.data->mname);
-        survive = TRUE;
-    } else if (Lifesaved && (how <= GENOCIDED)) {
-        pline("But wait...");
-        makeknown(AMULET_OF_LIFE_SAVING);
-        Your("medallion %s!", !Blind ? "begins to glow" : "feels warm");
-        if (how == CHOKING)
-            You("vomit ...");
-        You_feel("much better!");
-        pline_The("medallion crumbles to dust!");
-        if (uamul)
-            useup(uamul);
-
-        (void) adjattrib(A_CON, -1, TRUE);
-        savelife(how);
-        if (how == GENOCIDED) {
-            pline("Unfortunately you are still genocided...");
-        } else {
-            livelog_write_string(LL_LIFESAVE, "averted death");
+        if (uamul && uamul->otyp == AMULET_OF_REINCARNATION) {
+            makeknown(AMULET_OF_REINCARNATION);
+            Your("medallion %s!", !Hallucination ? "begins to blaze with energy" : "feels hot");
+            You("are given another chance at life!");
+            if (uamul)
+                useup(uamul);
+            HUnchanging = 0L;
+            polyself(3);
+            savelife(how);
+            HUnchanging |= FROMOUTSIDE;
+            livelog_printf(LL_LIFESAVE, "was reincarnated as %s",
+                an(g.youmonst.data->mname));
             survive = TRUE;
+        } else {
+            makeknown(AMULET_OF_LIFE_SAVING);
+            Your("medallion %s!", !Blind ? "begins to glow" : "feels warm");
+            if (how == CHOKING)
+                You("vomit ...");
+            You_feel("much better!");
+            pline_The("medallion crumbles to dust!");
+            if (uamul)
+                useup(uamul);
+
+            (void) adjattrib(A_CON, -1, TRUE);
+            savelife(how);
+            if (how == GENOCIDED) {
+                pline("Unfortunately you are still genocided...");
+            } else {
+                livelog_write_string(LL_LIFESAVE, "averted death");
+                survive = TRUE;
+            }
         }
     }
     /* explore and wizard modes offer player the option to keep playing */


### PR DESCRIPTION
Previously, a worn amulet of reincarnation would be activated by any end to the game, including quitting or escaping. This oversight has been corrected; now, like an amulet of life saving, it will only trigger if the hero was killed.