### PR TITLE
Fix message for wielded moldy corpse

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -2133,7 +2133,7 @@ boolean moldy;
             if (is_uwep) {
                 if (moldy) {
                     pline_The("moldy corpse in your %s grows into %s!",
-                        body_part(HAND), canspotmon(mtmp) ? a_monnam(mtmp))
+                        body_part(HAND), canspotmon(mtmp) ? a_monnam(mtmp)
                                                           : "a monster");
                 }
                 else

--- a/src/do.c
+++ b/src/do.c
@@ -2134,7 +2134,7 @@ boolean moldy;
                 if (moldy) {
                     pline_The("moldy corpse in your %s grows into %s!",
                         body_part(HAND), canspotmon(mtmp) ? a_monnam(mtmp))
-                                                          : "a monster";
+                                                          : "a monster");
                 }
                 else
                     pline_The("%s writhes out of your grasp!", cname);

--- a/src/do.c
+++ b/src/do.c
@@ -2132,8 +2132,9 @@ boolean moldy;
         case OBJ_INVENT:
             if (is_uwep) {
                 if (moldy) {
-                    pline_The("moldy %s in your hand grows into a %s!", cname,
-                              mon_nam(mtmp));
+                    pline_The("moldy corpse in your %s grows into %s!",
+                        body_part(HAND), canspotmon(mtmp) ? a_monnam(mtmp))
+                                                          : "a monster";
                 }
                 else
                     pline_The("%s writhes out of your grasp!", cname);
@@ -2148,7 +2149,7 @@ boolean moldy;
                 if (moldy)
                     pline("%s grows on a moldy corpse!", Amonnam(mtmp));
                 else if (pm == PM_DEATH) {
-                    pline("%s rises from the dead in a whirl of specral skulls!",
+                    pline("%s rises from the dead in a whirl of spectral skulls!",
                         Monnam(mtmp));
                 } else if (pm == PM_PESTILENCE) {
                     pline("%s rises from the dead in a churning pillar of flies!",


### PR DESCRIPTION
The previous version would produce messages such as "The moldy lichen corpse in your hand grows into a the lichen!" Now, the message will read "The moldy corpse in your <hand> grows into a lichen!" with <hand> replaced by the appropriate body part. (If the fungus is unseen, the corpse "grows into a monster" rather than "grows into it".)