### PR TITLE
Fix Blood Magic edge case

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -1005,6 +1005,7 @@ boolean atme;
     int otyp, skill, role_skill, res = 0;
     boolean confused = (Confusion != 0);
     boolean physical_damage = FALSE;
+    boolean failed = FALSE;
     struct obj *pseudo;
     struct monst *mtmp;
     coord cc;
@@ -1132,10 +1133,8 @@ boolean atme;
 
     chance = percent_success(spell);
     if (confused || (rnd(100) > chance)) {
-        You("fail to cast the spell correctly.");
-        u.uen -= energy / 2;
-        g.context.botl = 1;
-        return 1;
+        energy /= 2;
+        failed = TRUE;
     }
 
     /* only can hit this case if using blood magic */
@@ -1151,6 +1150,12 @@ boolean atme;
         u.uen -= energy;
     }
     g.context.botl = 1;
+
+    if (failed) {
+        You("fail to cast the spell correctly.");
+        return 1;
+    }
+
     exercise(A_WIS, TRUE);
     /* pseudo is a temporary "false" object containing the spell stats */
     pseudo = mksobj(spellid(spell), FALSE, FALSE);


### PR DESCRIPTION
Blood magic causes hero energy to dip into negative numbers when the
spell fails (due to confusion or a high failure rate), then causes massive damage upon success (because damage done is calculated by subtracting `u.uen` from spell energy cost; when `u.uen` is negative this *increases* the damage done, potentially by a massive amount since there's no lower bound to how negative the hero's energy can get). This commit should fix this issue.