### PR TITLE
Fix selfpoly'd crystal golem breath attack handling

### DIFF
--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1205,12 +1205,14 @@ dobreathe()
         return 0;
 
     mattk = attacktype_fordmg(g.youmonst.data, AT_BREA, AD_ANY);
+    int typ = (mattk->adtyp == AD_RBRE) ? rnd(AD_PSYC) : mattk->adtyp;
+
     if (!mattk)
         impossible("bad breath attack?"); /* mouthwash needed... */
     else if (!u.dx && !u.dy && !u.dz)
         ubreatheu(mattk);
     else
-        buzz((int) (20 + mattk->adtyp - 1), (int) mattk->damn, u.ux, u.uy,
+        buzz((int) (20 + typ - 1), (int) mattk->damn, u.ux, u.uy,
              u.dx, u.dy);
     return 1;
 }

--- a/src/zap.c
+++ b/src/zap.c
@@ -3021,7 +3021,8 @@ void
 ubreatheu(mattk)
 struct attack *mattk;
 {
-    int dtyp = 20 + mattk->adtyp - 1;      /* breath by hero */
+    int typ = (mattk->adtyp == AD_RBRE) ? rnd(AD_PSYC) : mattk->adtyp; /* breath by hero */
+    int dtyp = 20 + typ - 1;
     const char *fltxt = flash_types[dtyp]; /* blast of <something> */
 
     zhitu(dtyp, mattk->damn, fltxt, u.ux, u.uy);


### PR DESCRIPTION
When polymorphed into a crystal golem, using your `#monster` breath weapon will crash the game (more specifically, the game will crash on an attempt to print the breath type name in something like \`\`the blast of \<type\> bounces!''). This is because the crystal golem's breath attack type is `AD_RBRE`, a magic number of 68, and `dobuzz` expects a specific physical type value <=10. This pull adds code to explicitly convert `AD_RBRE` to a random physical attack type for `buzz` and `ubreatheu`, like non-player monster breath attacks already do.