### PR TITLE
Show correct sexual orientation in options list

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -1370,9 +1370,7 @@ char *op;
     if (req == get_val) {
         if (!opts)
             return optn_err;
-        /* Sprintf(opts, "%s", rolestring(flags.initgend, genders, adj)); */
-        /* TODO: Fix me */
-        Sprintf(opts, "orientation??????????");
+        Sprintf(opts, "%s", rolestring(flags.initorientation, orientations, adj));
         return optn_ok;
     }
     return optn_ok;

--- a/src/options.c
+++ b/src/options.c
@@ -1352,16 +1352,17 @@ char *op;
         return optn_ok;
     }
     if (req == do_set) {
-        /* gender:string */
+        /* orientation:string */
         if (parse_role_opts(optidx, negated, allopt[optidx].name, opts, &op)) {
             if ((flags.initorientation = str2orientation(op)) == ROLE_NONE) {
                 config_error_add("Unknown %s '%s'", allopt[optidx].name, op);
+		flags.orientation = flags.initorientation = SEX_STRAIGHT;
                 return optn_err;
             } else
                 flags.orientation = flags.initorientation;
         } else {
             /* TODO: Find way to make straight not the default. */
-            flags.orientation = SEX_STRAIGHT;
+            flags.orientation = flags.initorientation = SEX_STRAIGHT;
             return optn_silenterr;
         }
         return optn_ok;

--- a/src/options.c
+++ b/src/options.c
@@ -1356,7 +1356,7 @@ char *op;
         if (parse_role_opts(optidx, negated, allopt[optidx].name, opts, &op)) {
             if ((flags.initorientation = str2orientation(op)) == ROLE_NONE) {
                 config_error_add("Unknown %s '%s'", allopt[optidx].name, op);
-		flags.orientation = flags.initorientation = SEX_STRAIGHT;
+                flags.orientation = flags.initorientation = SEX_STRAIGHT;
                 return optn_err;
             } else
                 flags.orientation = flags.initorientation;

--- a/src/role.c
+++ b/src/role.c
@@ -1361,7 +1361,7 @@ const char *str;
 
     /* Is str valid? */
     if (!str || !str[0])
-        return SEX_STRAIGHT;
+        return ROLE_NONE;
 
     /* Match as much of str as is provided */
     len = strlen(str);
@@ -1375,7 +1375,7 @@ const char *str;
         return rn2(ROLE_ORIENTATIONS);
 
     /* Couldn't find anything appropriate */
-    return SEX_STRAIGHT;
+    return ROLE_NONE;
 }
 
 boolean


### PR DESCRIPTION
I think this should make orientation print correctly in the options menu (<kbd>O</kbd>); it's somewhat confusing to set `orientation` in an rcfile and not be able to confirm what it's set to in-game, especially if you have set it to something like `random`.

This also displays an error message (as intended?) when `orientation` is set to a nonsense value that can't be parsed/understood; previously the game defaulted silently to `straight`. It still defaults to `straight`, but this way at least you'll have some feedback if you fatfinger `OPTIONS=orientation:asxeual` or something.