### PR TITLE
Fix up hero/monster reflection

### DIFF
--- a/src/muse.c
+++ b/src/muse.c
@@ -3052,10 +3052,16 @@ const char *str;
         if (str)
             pline(str, s_suffix(mon_nam(mon)), "body");
         return TRUE;
-    /* this REALLY needed a base case. Currently handles cartomancer artifact */
     } else {
-        if (str)
-            pline(str, mon_nam(mon), "");
+        /* check monster inventory for artifacts that grant reflection when
+         * carried; handles Void Lily */
+        for (orefl = mon->minvent; orefl; orefl = orefl->nobj) {
+            if (orefl->oartifact && arti_reflects(orefl)) {
+                if (str)
+                    pline(str, s_suffix(mon_nam(mon)), "body");
+                return TRUE;
+            }
+        }
     }
     return FALSE;
 }

--- a/src/muse.c
+++ b/src/muse.c
@@ -3095,15 +3095,18 @@ const char *fmt, *str;
         if (fmt && str)
             pline(fmt, str, "scales");
         return TRUE;
-    } else if (HReflecting) {
-        if (fmt && str) {
+    } else if (g.youmonst.data == &mons[PM_SILVER_GOLEM]
+            || g.youmonst.data == &mons[PM_CRYSTAL_GOLEM]
+            || g.youmonst.data == &mons[PM_SAPPHIRE_GOLEM]) {
+        if (fmt && str)
             pline(fmt, str, "body");
-        }
-    /* this also really needed a base case. */
-    } else {
-        if (fmt && str) {
+        return TRUE;
+    } else if (Reflecting) {
+        /* intrinsic or extrinsic reflection from other source
+         * e.g. cartomancer artifact */
+        if (fmt && str)
             pline(fmt, str, "body");
-        }
+	return TRUE;
     }
     return FALSE;
 }


### PR DESCRIPTION
Some changes to `ureflects` and `mon_reflects` for handling the reflection-while-carried property of the Holographic Void Lily have caused reflection messages to be printed by default, even if the hero or monster is not reflective.

It's less common for the hero, since most calling functions do something like `if (Reflecting) { (void) ureflects("It bounces off your %s%s", "") }` (i.e. use it for determining the source of reflection, rather than testing whether the hero has reflection at all), but there are some exceptions -- for example, a floating eye's gaze uses `ureflects` to test directly for reflection, so even a non-reflective character will see the gaze \`\`reflected by your body'' before being frozen in place:

https://github.com/NullCGT/SpliceHack/blob/development/src/uhitm.c#L3509-L3512

Monster reflection, on the other hand, is generally tested directly by `mon_reflects`, so defaulting to printing a message means there are various spurious messages printed about reflection. 

Plus, the return value of `FALSE` means that reflection from an unusual source isn't granted even when a monster *should* have it (namely from carrying the Cartomancer quest artifact). The same is true of cases where player reflection is tested directly by calling `ureflects`: currently, having the Void Lily in inventory will not grant you reflection when attacking a floating eye.

Please check it out yourself, but I think this will make everything work as intended!