### PR TITLE
Prevent dragonmasters and knights from slipping...

### DIFF
--- a/src/steed.c
+++ b/src/steed.c
@@ -468,7 +468,8 @@ boolean force;      /* Quietly force this animal */
              uarm->oeroded ? "rusty" : "corroded", mon_nam(mtmp));
         return (FALSE);
     }
-    if (!force
+    if (!force 
+        && !(Role_if(PM_KNIGHT) || Role_if(PM_DRAGONMASTER))
         && (Confusion || Fumbling || Glib || Wounded_legs || otmp->cursed
             || (u.ulevel + mtmp->mtame < rnd(MAXULEV / 2 + 5)))) {
         if (Levitation) {


### PR DESCRIPTION
...off their steeds while attempting to mount up.

not sure about the syntax there, with `!(Role_if(PM_KNIGHT) || Role_if(PM_DRAGONMASTER))`, but i'll use travis-ci to see if i got it right!