### PR TITLE
Kicking a tame monster is always "clumsy"

### DIFF
--- a/src/dokick.c
+++ b/src/dokick.c
@@ -246,6 +246,9 @@ xchar x, y;
 
     else if (uarm && objects[uarm->otyp].oc_bulky && ACURR(A_DEX) < rnd(25))
         clumsy = TRUE;
+    
+    else if (mon->mtame)
+        clumsy = TRUE;
  doit:
     You("kick %s.", mon_nam(mon));
     if (!rn2(clumsy ? 3 : 4) && (clumsy || !bigmonst(mon->data))


### PR DESCRIPTION
This is intended to prevent cartomancer unique death abuse in junethack. 

It might be fun to extend this into providing a useful reason to kick pets: it causes them to wake up (if asleep) and make one random move, if they're standing in a spot and you'd prefer them to be in a different spot.  It shouldn't abuse tameness in that case.