### PR TITLE
Ditch item material for encyclopedia lookups

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -1339,6 +1339,7 @@ char *supplemental_name;
     unsigned long txt_offset = 0L;
     winid datawin = WIN_ERR;
     short otyp;
+    int l, i;
 
     fp = dlb_fopen(DATAFILE, "r");
     if (!fp) {
@@ -1429,6 +1430,18 @@ char *supplemental_name;
         if (*dbase_str == ' ')
             ++dbase_str;
     }
+
+    /* remove material type */
+    for (i = 1; i < NUM_MATERIAL_TYPES; i++) {
+        l = strlen(materialnm[i]);
+        Strcpy(buf, materialnm[i]);
+        Strcat(buf, " ");
+        if (!strncmp(dbase_str, buf, ++l)) {
+            dbase_str += l;
+            break;
+        }
+    }
+
     /* "towel", "wet towel", and "moist towel" share one data.base entry;
        for "wet towel", we keep prefix so that the prompt will ask about
        "wet towel"; for "moist towel", we also want to ask about "wet towel".

--- a/src/pager.c
+++ b/src/pager.c
@@ -1432,14 +1432,15 @@ char *supplemental_name;
     }
 
     /* remove material type */
-    for (i = 1; i < NUM_MATERIAL_TYPES; i++) {
+    for (i = 1; i <= NUM_MATERIAL_TYPES; i++) {
         l = strlen(materialnm[i]);
-        Strcpy(material, materialnm[i]);
-        Strcat(material, " ");
-        if (!strncmp(dbase_str, material, ++l)) {
+        Strcpy(buf, materialnm[i]);
+        Strcat(buf, " ");
+        if (!strncmp(dbase_str, buf, ++l)) {
+            Strcpy(material, buf);
             dbase_str += l;
             break;
-        }
+        } 
     }
 
     /* "towel", "wet towel", and "moist towel" share one data.base entry;

--- a/src/pager.c
+++ b/src/pager.c
@@ -1497,6 +1497,9 @@ char *supplemental_name;
         if (!alt)
             alt = makesingular(dbase_str);
 
+        /* generate alternate version with material name */
+        Strcat(material, dbase_str);
+
         pass1found_in_file = FALSE;
         for (pass = !strcmp(alt, dbase_str) ? 0 : 1; pass >= 0; --pass) {
             found_in_file = skipping_entry = FALSE;
@@ -1528,7 +1531,8 @@ char *supplemental_name;
                     /* if we match a key that begins with "~", skip
                        this entry */
                     chk_skip = (*buf == '~') ? 1 : 0;
-                    if ((pass == 0 && pmatch(&buf[chk_skip], dbase_str))
+                    if ((pass == 0 && ((pmatch(&buf[chk_skip], dbase_str) ||
+                                        pmatch(&buf[chk_skip], material))))
                         || (pass == 1 && alt && pmatch(&buf[chk_skip], alt))) {
                         if (chk_skip) {
                             skipping_entry = TRUE;
@@ -1563,9 +1567,6 @@ char *supplemental_name;
                     goto checkfile_done;
                 }
             }
-
-            /* generate alternate version with material name */
-            Strcat(material, dbase_str);
 
             /* monster lookup: try to parse as a monster */
             pm = NULL;

--- a/src/pager.c
+++ b/src/pager.c
@@ -1334,7 +1334,7 @@ boolean user_typed_name, without_asking;
 char *supplemental_name;
 {
     dlb *fp;
-    char buf[BUFSZ], newstr[BUFSZ], givenname[BUFSZ];
+    char buf[BUFSZ], newstr[BUFSZ], givenname[BUFSZ], material[BUFSZ];
     char *ep, *dbase_str;
     unsigned long txt_offset = 0L;
     winid datawin = WIN_ERR;
@@ -1434,9 +1434,9 @@ char *supplemental_name;
     /* remove material type */
     for (i = 1; i < NUM_MATERIAL_TYPES; i++) {
         l = strlen(materialnm[i]);
-        Strcpy(buf, materialnm[i]);
-        Strcat(buf, " ");
-        if (!strncmp(dbase_str, buf, ++l)) {
+        Strcpy(material, materialnm[i]);
+        Strcat(material, " ");
+        if (!strncmp(dbase_str, material, ++l)) {
             dbase_str += l;
             break;
         }
@@ -1563,16 +1563,26 @@ char *supplemental_name;
                 }
             }
 
+            /* generate alternate version with material name */
+            Strcat(material, dbase_str);
+
             /* monster lookup: try to parse as a monster */
             pm = NULL;
-            int mndx = name_to_mon(dbase_str);
+            /* first try with material */
+            int mndx = name_to_mon(material);
+            /* if no results, try base version */
+            if (mndx == NON_PM)
+                mndx = name_to_mon(dbase_str);
             if (mndx != NON_PM) {
                 pm = &mons[mndx];
             }
 
             /* object lookup: try to parse as an object */
-            otyp = name_to_otyp(dbase_str);
-
+            /* first try with material */
+            otyp = name_to_otyp(material);
+            /* if no results, try base version */
+            if (otyp == STRANGE_OBJECT)
+                otyp = name_to_otyp(dbase_str);
 
             /* prompt for more info (if using whatis to navigate the map) */
             yes_to_moreinfo = FALSE;

--- a/src/pager.c
+++ b/src/pager.c
@@ -1339,7 +1339,7 @@ char *supplemental_name;
     unsigned long txt_offset = 0L;
     winid datawin = WIN_ERR;
     short otyp;
-    int l, i;
+    int i;
 
     fp = dlb_fopen(DATAFILE, "r");
     if (!fp) {
@@ -1432,6 +1432,7 @@ char *supplemental_name;
     }
 
     /* remove material type */
+    int l;
     for (i = 1; i <= NUM_MATERIAL_TYPES; i++) {
         l = strlen(materialnm[i]);
         Strcpy(buf, materialnm[i]);
@@ -1550,7 +1551,6 @@ char *supplemental_name;
             /* database entry should exist, now find where it is */
             long entry_offset, fseekoffset;
             int entry_count;
-            int i;
             if (found_in_file) {
                 /* skip over other possible matches for the info */
                 do {

--- a/src/pager.c
+++ b/src/pager.c
@@ -1568,20 +1568,16 @@ char *supplemental_name;
 
             /* monster lookup: try to parse as a monster */
             pm = NULL;
-            /* first try with material */
-            int mndx = name_to_mon(material);
-            /* if no results, try base version */
-            if (mndx == NON_PM)
+            /* first try with material, then try base version if no results */
+            int mndx;
+            if ((mndx = name_to_mon(material)) == NON_PM)
                 mndx = name_to_mon(dbase_str);
-            if (mndx != NON_PM) {
+            if (mndx != NON_PM)
                 pm = &mons[mndx];
-            }
 
             /* object lookup: try to parse as an object */
-            /* first try with material */
-            otyp = name_to_otyp(material);
-            /* if no results, try base version */
-            if (otyp == STRANGE_OBJECT)
+            /* as with monster lookup, first try material, then base version */
+            if ((otyp = name_to_otyp(material)) == STRANGE_OBJECT)
                 otyp = name_to_otyp(dbase_str);
 
             /* prompt for more info (if using whatis to navigate the map) */

--- a/src/pager.c
+++ b/src/pager.c
@@ -706,6 +706,10 @@ struct permonst * pm;
     }
 #define MONPUTSTR(str) putstr(datawin, ATR_NONE, str)
 
+    Sprintf(buf, "Monster lookup for \"%s\":", pm->mname);
+    putstr(datawin, ATR_BOLD, buf);
+    MONPUTSTR("");
+
     /* Misc */
     Sprintf(buf, "%s", mname);
     putstr(datawin, ATR_INVERSE, mname);
@@ -943,6 +947,10 @@ add_obj_info(winid datawin, short otyp)
         if (*buf) { Strcat(buf, ", "); }    \
         Strcat(buf, str);                   \
     }
+
+    Sprintf(buf, "Object lookup for \"%s\":", safe_typename(otyp));
+    putstr(datawin, ATR_BOLD, buf);
+    OBJPUTSTR("");
 
     /* Misc */
     Sprintf(buf, "%s", oc.oc_name_known ? OBJ_NAME(oc) : OBJ_DESCR(oc));
@@ -1334,11 +1342,11 @@ boolean user_typed_name, without_asking;
 char *supplemental_name;
 {
     dlb *fp;
-    char buf[BUFSZ], newstr[BUFSZ], givenname[BUFSZ], material[BUFSZ];
-    char *ep, *dbase_str;
+    char buf[BUFSZ], newstr[BUFSZ], givenname[BUFSZ];
+    char *ep, *dbase_str, *dbase_str_with_material;
     unsigned long txt_offset = 0L;
     winid datawin = WIN_ERR;
-    short otyp;
+    short otyp, mat;
     int i;
 
     fp = dlb_fopen(DATAFILE, "r");
@@ -1431,19 +1439,6 @@ char *supplemental_name;
             ++dbase_str;
     }
 
-    /* remove material type */
-    int l;
-    for (i = 1; i <= NUM_MATERIAL_TYPES; i++) {
-        l = strlen(materialnm[i]);
-        Strcpy(buf, materialnm[i]);
-        Strcat(buf, " ");
-        if (!strncmp(dbase_str, buf, ++l)) {
-            Strcpy(material, buf);
-            dbase_str += l;
-            break;
-        } 
-    }
-
     /* "towel", "wet towel", and "moist towel" share one data.base entry;
        for "wet towel", we keep prefix so that the prompt will ask about
        "wet towel"; for "moist towel", we also want to ask about "wet towel".
@@ -1452,6 +1447,28 @@ char *supplemental_name;
     if (!strncmp(dbase_str, "moist towel", 11))
         (void) strncpy(dbase_str += 2, "wet", 3); /* skip "mo" replace "ist" */
 
+    /* Remove material, if it exists, but store the original value in
+     * dbase_str_with_material. It should be cut out of dbase_str as a prefix
+     * in order for the alt handling below to function properly.
+     * Note that this assumes that material is always the last thing that needs
+     * to be stripped out (e.g. it will not strip things out if dbase_str is
+     * "silver +0 sword").
+     * This is clunky in how it adds a third possibility that needs to be
+     * pmatch()'ed; a better future refactor of this code would be to collect an
+     * arbitrary number of possible strings as needed, then iterate through
+     * them. */
+    dbase_str_with_material = dbase_str;
+    for (mat = 1; mat < NUM_MATERIAL_TYPES; ++mat) {
+        unsigned int len = strlen(materialnm[mat]);
+        /* check for e.g. "gold " without constructing it as a string */
+        if (!strncmp(dbase_str, materialnm[mat], len) && strlen(dbase_str) > len
+            && dbase_str[len] == ' ') {
+            dbase_str_with_material = dbase_str;
+            dbase_str += len + 1;
+            break;
+        }
+    }
+
     /* Make sure the name is non-empty. */
     if (*dbase_str) {
         long pass1offset = -1L;
@@ -1459,6 +1476,9 @@ char *supplemental_name;
         boolean yes_to_moreinfo, found_in_file, pass1found_in_file,
                 skipping_entry;
         char *sp, *ap, *alt = 0; /* alternate description */
+        char *encycl_matched = 0; /* which version of the string matched
+                                     (for later printing) */
+        char matcher[BUFSZ];      /* the string it matched against */
 
         /* adjust the input to remove "named " and "called " */
         if ((ep = strstri(dbase_str, " named ")) != 0) {
@@ -1498,9 +1518,6 @@ char *supplemental_name;
         if (!alt)
             alt = makesingular(dbase_str);
 
-        /* generate alternate version with material name */
-        Strcat(material, dbase_str);
-
         pass1found_in_file = FALSE;
         for (pass = !strcmp(alt, dbase_str) ? 0 : 1; pass >= 0; --pass) {
             found_in_file = skipping_entry = FALSE;
@@ -1532,14 +1549,25 @@ char *supplemental_name;
                     /* if we match a key that begins with "~", skip
                        this entry */
                     chk_skip = (*buf == '~') ? 1 : 0;
-                    if ((pass == 0 && ((pmatch(&buf[chk_skip], dbase_str) ||
-                                        pmatch(&buf[chk_skip], material))))
-                        || (pass == 1 && alt && pmatch(&buf[chk_skip], alt))) {
+                    encycl_matched = (char *) 0;
+                    if (pass == 0) {
+                        if (pmatch(&buf[chk_skip], dbase_str_with_material)) {
+                            encycl_matched = dbase_str_with_material;
+                        }
+                        else if (pmatch(&buf[chk_skip], dbase_str)) {
+                            encycl_matched = dbase_str;
+                        }
+                    }
+                    else if (pass == 1 && alt && pmatch(&buf[chk_skip], alt)) {
+                        encycl_matched = alt;
+                    }
+                    if (encycl_matched) {
                         if (chk_skip) {
                             skipping_entry = TRUE;
                             continue;
                         } else {
                             found_in_file = TRUE;
+                            Strcpy(matcher, buf);
                             if (pass == 1)
                                 pass1found_in_file = TRUE;
                             break;
@@ -1568,19 +1596,21 @@ char *supplemental_name;
                 }
             }
 
-            /* monster lookup: try to parse as a monster */
+            /* monster lookup: try to parse as a monster
+             * use dbase_str_with_material here; if it differs from
+             * dbase_str, then it's likely that dbase_str stripped off the
+             * "iron" from "iron golem" or something. */
             pm = NULL;
-            /* first try with material, then try base version if no results */
-            int mndx;
-            if ((mndx = name_to_mon(material)) == NON_PM)
-                mndx = name_to_mon(dbase_str);
+            int mndx = name_to_mon(dbase_str_with_material);
             if (mndx != NON_PM)
                 pm = &mons[mndx];
 
-            /* object lookup: try to parse as an object */
-            /* as with monster lookup, first try material, then base version */
-            if ((otyp = name_to_otyp(material)) == STRANGE_OBJECT)
+            /* object lookup: try to parse as an object, and try the material
+             * version of the string first */
+            otyp = name_to_otyp(dbase_str_with_material);
+            if (otyp == STRANGE_OBJECT) {
                 otyp = name_to_otyp(dbase_str);
+            }
 
             /* prompt for more info (if using whatis to navigate the map) */
             yes_to_moreinfo = FALSE;
@@ -1627,12 +1657,20 @@ char *supplemental_name;
 
                     /* encyclopedia entry */
                     if (found_in_file) {
+                        char titlebuf[BUFSZ];
                         if (dlb_fseek(fp, (long) txt_offset + entry_offset,
                                         SEEK_SET) < 0) {
                             pline("? Seek error on 'data' file!");
                             (void) dlb_fclose(fp);
                             return;
                         }
+
+                        Sprintf(titlebuf,
+                                "Encyclopedia entry for \"%s\" (matched to \"%s\"):",
+                                encycl_matched, matcher);
+                        putstr(datawin, ATR_BOLD, titlebuf);
+                        putstr(datawin, ATR_NONE, "");
+
                         for (i = 0; i < entry_count; i++) {
                             /* room for 1-tab or 8-space prefix + BUFSZ-1 + \0 */
                             char tabbuf[BUFSZ + 8], *tp;
@@ -1675,7 +1713,7 @@ char *supplemental_name;
 
  bad_data_file:
     impossible("'data' file in wrong format or corrupted");
- checkfile_done:
+    checkfile_done:
     if (datawin != WIN_ERR)
         destroy_nhwindow(datawin);
     (void) dlb_fclose(fp);


### PR DESCRIPTION
Encyclopedia/database lookups currently don't work for items with a special material (e.g. pressing <kbd>/</kbd> <kbd>i</kbd> <kbd>q</kbd> to lookup `q - an uncursed +0 silver banded mail` will print \`\`I don't have any information on those things, '' even though `q - an uncursed +0 banded mail` would return stats about the item.

The function that handles lookups like that, `checkfile`, does so by stripping words like \`an', \`uncursed', \`+0', etc, to pare down the string to \`banded mail' before searching for it in the database. It currently doesn't remove material names, so it ends up looking for \`silver banded mail', which returns no results. 

This adds a system to remove material names from the lookup string so that items with special materials will return results from `data.base`.