### PR TITLE
Pumpkin fixes

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2923,7 +2923,7 @@ struct obj *obj;
            be wielded/alt-wielded/quivered, so tests on those are limited */
         what = 0;
         if (owornmask & W_ARMOR) {
-            if (obj->oclass != ARMOR_CLASS)
+            if (obj->oclass != ARMOR_CLASS && obj->otyp != PUMPKIN)
                 what = "armor";
             /* 3.6: dragon scale mail reverts to dragon scales when
                becoming embedded in poly'd hero's skin */

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -884,7 +884,8 @@ boolean artif;
                                  + (otmp->otyp - GLOB_OF_GRAY_OOZE);
             } else {
                 if (otmp->otyp != CORPSE && otmp->otyp != MEAT_RING
-                    && otmp->otyp != KELP_FROND && !rn2(6)) {
+                    && otmp->otyp != PUMPKIN && otmp->otyp != KELP_FROND
+                    && !rn2(6)) {
                     otmp->quan = 2L;
                 }
             }

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -4353,7 +4353,7 @@ struct obj *no_wish;
     }
 
     /* if player specified a reasonable count, maybe honor it */
-    if (cnt > 1 && objects[typ].oc_merge
+    if (cnt > 0 && objects[typ].oc_merge
         && (wizard || cnt < rnd(6) || (cnt <= 7 && Is_candle(otmp))
             || (cnt <= 20 && ((oclass == WEAPON_CLASS && is_ammo(otmp))
                               || typ == ROCK || is_missile(otmp))))) {


### PR DESCRIPTION
Pumpkins cause an `impossible()` when worn, since `sanity_check_worn` will freak out if something being worn as armor doesn't use the armor class. Meat rings already are explicitly accounted for in this function, so I added explicit checks for pumpkins as well.

~Also, pumpkins are marked as impossible to merge, but they still seem to merge sometimes for me. Need to figure that out as well. It mostly happens when wishing, and if you manually unmerge the stack it won't merge again, so it's probably a problem(?) with the wishing logic rather than with the object itself.~
Figured this out I think: pumpkins weren't accounted for in `mksobj`, so they were treated like other food and sometimes `obj->quan` was set to 2 on generation.