### PR TITLE
Fix taming cats by throwing catnip

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1891,6 +1891,13 @@ register struct obj *obj; /* g.thrownobj or g.kickedobj or uwep */
                && (guaranteed_hit || ACURR(A_DEX) > rnd(25))) {
         potionhit(mon, obj, POTHIT_HERO_THROW);
         return 1;
+    } else if (obj->otyp == PINCH_OF_CATNIP
+                && is_feline(mon->data)) {
+        if (!Blind)
+            pline("%s chases %s tail!", Monnam(mon), mhis(mon));
+        (void) tamedog(mon, (struct obj *) 0);
+        mon->mconf = 1;
+        return 1;
     } else if (befriend_with_obj(mon->data, obj)
                || (mon->mtame && dogfood(mon, obj) <= ACCFOOD)) {
         if (tamedog(mon, obj)) {

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1285,7 +1285,8 @@ int dieroll;
                 case PINCH_OF_CATNIP:
                     tmp = 0;
                     if (is_feline(mdat)) {
-                        pline("%s chases their tail!", Monnam(mon));
+                        if (!Blind)
+                            pline("%s chases %s tail!", Monnam(mon), mhis(mon));
                         (void) tamedog(mon, (struct obj *) 0);
                         mon->mconf = 1;
                         if (thrown)
@@ -1294,7 +1295,7 @@ int dieroll;
                             useup(obj);
                         return FALSE;
                     } else {
-                        pline("Poof! Catnip flies everywhere!");
+                        You("%s catnip fly everywhere!", Blind ? "feel" : "see");
                         setmangry(mon, TRUE);
                     }
                     if (thrown)


### PR DESCRIPTION
Putting catnip taming in uhitm.c means it's relatively hard to actually hit a cat with thrown catnip, compared to standard animal taming (e.g. throwing a tripe ration to a dog); since there is already a downside to using catnip -- confusing the cat that gets hit with it -- it seems needless to make it tough to throw successfully on top of that.

Also updates existing code to consider hero blindness when printing messages about seeing the cat chase its tail, etc.