### PR TITLE
Fix magic marker/tinning kit/expensive camera initial charges

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -956,6 +956,8 @@ boolean artif;
             case EXPENSIVE_CAMERA:
             case TINNING_KIT:
             case MAGIC_MARKER:
+                otmp->spe = rn1(70, 30); /* 0..69 + 30 => 30..99 */
+                break;
             case CAN_OF_GREASE:
                 otmp->spe = rn1(21, 5); /* 0..20 + 5 => 5..25 */
                 blessorcurse(otmp, 10);


### PR DESCRIPTION
Somehow, in 33828f (Sewing kits and ghoul grafts.) the lines for charges for those 3 tools were removed. This just adds them back in.