### PR TITLE
Give glowing monsters a larger light radius

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -57,6 +57,7 @@ Visual
 - Tiled mode now includes an indicator to denote if a monster is part of a rider/steed
   pair.
 - Added a new splash screen to the Windows build.
+- Yellow lights and glowing dragons now emit quite a bit of light.
 
 QOL
 - Show the carrying capacity of a player and the number of slots in their

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -269,16 +269,19 @@
 
 /* this returns the light's range, or 0 if none; if we add more light emitting
    monsters, we'll likely have to add a new light range field to mons[] */
-#define emits_light(ptr)                                          \
-    (((ptr)->mlet == S_LIGHT || (ptr) == &mons[PM_FLAMING_SPHERE] \
-      || (ptr) == &mons[PM_SHOCKING_SPHERE]                       \
-      || (ptr) == &mons[PM_FIRE_VORTEX]                          \
+#define emits_light(ptr)                                         \
+    (((ptr)->mlet == S_LIGHT    				 \
       || (ptr) == &mons[PM_GOLD_DRAGON]                          \
       || (ptr) == &mons[PM_BABY_GOLD_DRAGON]                     \
-      || (ptr) == &mons[PM_WAX_GOLEM])                           \
-         ? 1                                                     \
+         ? 4							 \
+         : (ptr) == &mons[PM_FLAMING_SPHERE] 			 \
+        || (ptr) == &mons[PM_SHOCKING_SPHERE]                    \
+        || (ptr) == &mons[PM_FIRE_VORTEX]                        \
+        || (ptr) == &mons[PM_WAX_GOLEM])                         \
+         ? 2                                                     \
          : ((ptr) == &mons[PM_FIRE_ELEMENTAL]) ? 1 : 0)
-/*	[note: the light ranges above were reduced to 1 for performance...] */
+/*	[note: the light ranges above were reduced to 1 for performance...]
+	...many years ago. it's fine to increase it now. Credit: NHFourk */
 #define likes_lava(ptr) \
     (ptr == &mons[PM_FIRE_ELEMENTAL] || ptr == &mons[PM_SALAMANDER] \
           || ptr == &mons[PM_MAGMA_ELEMENTAL] \


### PR DESCRIPTION
The biggest gameplay implication is that brightly-glowing monsters can be seen approaching from around a corner, which is atmospheric, ominous, and cool.  This effect can be seen pretty regularly in Fourk, and doesn't have any impact on game performance in public servers.

This commit was significantly more involved in Fourk, as it included many mlet reassignments, and added a new monster flag: https://github.com/tsadok/nhfourk/commit/9705bbb34bf4ddc76fbbd3e4352b706477787f7b

Another thing i enjoy from Fourk: giving players a consolation prize when they don't start with rad rare inventory items (such as magic markers).  https://github.com/tsadok/nhfourk/commit/a45ee4f7f4e4ab75aa06a11366f297cd9a29216a  FIQhack's alternate solution is to make inventory items that are currently "sometimes" into "never" or "always", to reduce start-scumming.