### PR TITLE
Xnh fixes2

### DIFF
--- a/changelog-from-XNH
+++ b/changelog-from-XNH
@@ -6,3 +6,5 @@ Martial arts users, sasquatches, and players wearing kicking boots can no
 
 Martial arts attacks now always include skill damage bonuses, instead of
   randomly not getting them 75% of the time.
+
+ Pets won't fight each other even if they grudge each other.

--- a/changelog-from-XNH
+++ b/changelog-from-XNH
@@ -1,0 +1,8 @@
+ Magic lamps always release a djinni when rubbed instead of 1/3 of the time.
+
+Martial arts users, sasquatches, and players wearing kicking boots can no
+  longer miss a monster completely with a clumsy kick.
+
+
+Martial arts attacks now always include skill damage bonuses, instead of
+  randomly not getting them 75% of the time.

--- a/changelog-from-XNH
+++ b/changelog-from-XNH
@@ -10,3 +10,7 @@ Martial arts attacks now always include skill damage bonuses, instead of
  Pets won't fight each other even if they grudge each other.
 
  Hallucination protects you against all gaze attacks made by monsters.
+
+
+All wands that print an unambiguous message clue to their identity now
+  automatically type-identify when engraved with.

--- a/changelog-from-XNH
+++ b/changelog-from-XNH
@@ -8,3 +8,5 @@ Martial arts attacks now always include skill damage bonuses, instead of
   randomly not getting them 75% of the time.
 
  Pets won't fight each other even if they grudge each other.
+
+ Hallucination protects you against all gaze attacks made by monsters.

--- a/src/apply.c
+++ b/src/apply.c
@@ -1770,7 +1770,7 @@ dorub()
 
     /* now uwep is obj */
     if (uwep->otyp == MAGIC_LAMP) {
-        if (uwep->spe > 0 && !rn2(3)) {
+        if (uwep->spe > 0) {
             check_unpaid_usage(uwep, TRUE); /* unusual item use */
             /* bones preparation:  perform the lamp transformation
                before releasing the djinni in case the latter turns out
@@ -1785,8 +1785,6 @@ dorub()
             djinni_from_bottle(uwep);
             makeknown(MAGIC_LAMP);
             update_inventory();
-        } else if (rn2(2)) {
-            You("%s smoke.", !Blind ? "see a puff of" : "smell");
         } else
             pline1(nothing_happens);
     } else if (uwep->otyp == MOONSTONE) {

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -232,9 +232,17 @@ xchar x, y;
     i = -inv_weight();
     j = weight_cap();
 
+    /* What the following confusing if statements mean:
+     * If you are over 70% of carrying capacity, you go through a "deal no
+     * damage" check, and if that fails, a "clumsy kick" check.
+     * At this % of carrycap | Chance of no damage | Chance of clumsiness
+     *             [70%-80%) |                 1/4 |                  1/3
+     *             [80%-90%) |                 1/3 |                  1/2
+     *            [90%-100%) |                 1/2 |                   1
+     */
     if (i < (j * 3) / 10) {
         if (!rn2((i < j / 10) ? 2 : (i < j / 5) ? 3 : 4)) {
-            if (martial() && !rn2(2))
+            if (martial())
                 goto doit;
             Your("clumsy kick does no damage.");
             (void) passive(mon, uarmf, FALSE, 1, AT_KICK, FALSE);

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -2743,7 +2743,7 @@ struct attack *mattk;
        appropriate to what's currently being displayed, giving
        ordinary monsters a gaze attack when hero thinks he or she
        is facing a gazing creature, but let's not go that far...] */
-    if (Hallucination && rn2(4))
+    if (Hallucination)
         cancelled = TRUE;
 
     switch (mattk->adtyp) {

--- a/src/mon.c
+++ b/src/mon.c
@@ -1940,6 +1940,9 @@ struct monst *magr, /* monster that is currently deciding where to move */
     struct permonst *ma, *md;
     ma = magr->data;
     md = mdef->data;
+    /* Don't allow pets to fight each other. */
+    if (magr->mtame && mdef->mtame)
+        return 0;
     /* supposedly purple worms are attracted to shrieking because they
        like to eat shriekers, so attack the latter when feasible */
     if ((ma == &mons[PM_PURPLE_WORM] || ma == &mons[PM_BABY_PURPLE_WORM]) 


### PR DESCRIPTION
Per the conversation in https://github.com/NullCGT/SpliceHack/pull/89/ this only contains the following changes:

-     Rubbing a magic lamp always releases a djinni.
-     Martial arts users never have to deal with a clumsy kick.
-     Pets won't attack other pets, even if there's a grudge.
-     Hallucination negates all incoming gaze attacks.
-     Identify a wand when it prints an unambiguous message when engraving.

There were clear "yes" and "no" responses on most things, though it was a bit unclear whether Copperwater's justification for `Confused ID = Enlight` was convincing to NullCGT or not. And it's clear that you kinda like the medusa titan, but it's not clear if you think the Golden Nagas are maybe a sufficient replacement. So I didn't add those.

Thanks for splicehack, and reviewing the previous PR!  This is probably shippable.  😅 
(visualstudio failed, all other checks passed: https://travis-ci.org/github/RojjaCebolla/SpliceHack/builds/716988299 )
This closes  #89