### PR TITLE
Make returning artifacts always magically return

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1441,7 +1441,7 @@ struct obj *oldslot; /* for thrown-and-return used with !fixinv */
                 else
                     sho_obj_return_to_u(obj); /* display its flight */
 
-                if (!impaired && rn2(100)) {
+                if ((!impaired && rn2(100)) || obj->oartifact) {
                     pline("%s to your hand!", Tobjnam(obj, "return"));
                     obj = addinv_before(obj, oldslot);
                     (void) encumber_msg();


### PR DESCRIPTION
The 1% chance to fumble is small enough to not matter, for mundane weapons, but can be tragic with Mjollnir, which encourages players to avoid using its iconic feature.  Even if you're "impaired", mojo (and other artifact weapons that return, if they exist), will magically reappear in your hand!