### PR TITLE
Make dragonbane a lance, and first gift for Knight

### DIFF
--- a/include/artilist.h
+++ b/include/artilist.h
@@ -352,9 +352,9 @@ static NEARDATA struct artifact artilist[] = {
       FIRE(5, 0), FIRE(0, 0), NO_CARY, 0, A_NONE, NON_PM, NON_PM, 3000L,
       NO_COLOR),
 
-    A("Dragonbane", BROADSWORD,
+    A("Dragonbane", LANCE,
       (SPFX_RESTR | SPFX_DCLAS | SPFX_REFLECT), 0, S_DRAGON,
-      PHYS(5, 0), NO_DFNS, NO_CARY, 0, A_NONE, NON_PM, NON_PM, 500L,
+      PHYS(5, 0), NO_DFNS, NO_CARY, 0, A_LAWFUL, PM_KNIGHT, NON_PM, 500L,
       NO_COLOR),
 
     A("Demonbane", LONG_SWORD, (SPFX_RESTR | SPFX_WARN | SPFX_DFLAGH), 0, MH_DEMON,


### PR DESCRIPTION
This helps reduce the prevalence of longsword/broadsword base types, and provides a compelling alternative to excalibur.

This makes it almost the same as Dragonbane in FIQHack (except that in FH, the Banes deal 1d20 bonus damage, instead of double damage, so that they're useful at +0 enchantment)
https://nethackwiki.com/wiki/Dragonbane#FIQHack