### PR TITLE
Fix orientation setting

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -1351,7 +1351,7 @@ char *op;
         if (parse_role_opts(optidx, negated, allopt[optidx].name, opts, &op)) {
             if ((flags.initorientation = str2orientation(op)) == ROLE_NONE) {
                 config_error_add("Unknown %s '%s'", allopt[optidx].name, op);
-                flags.orientation = flags.initorientation = rn2(3);;
+                flags.orientation = flags.initorientation = rn2(NUM_ORIENTATIONS);;
                 return optn_err;
             } else
                 flags.orientation = flags.initorientation;

--- a/src/u_init.c
+++ b/src/u_init.c
@@ -802,7 +802,7 @@ u_init()
     struct attack* attkptr;
 
     flags.gender = flags.initgend;
-    if (!flags.initorientation)
+    if (flags.initorientation == ROLE_NONE)
         flags.orientation = flags.initorientation = rn2(NUM_ORIENTATIONS);
     if (flags.gender == GEND_N)
         record_achievement(ACH_NBIN);


### PR DESCRIPTION
Because straight orientation is `0` ([based on its index in `orientations`](https://github.com/NullCGT/SpliceHack/blob/7ff837b0b0a9b819811311808b84cbcb2115c09a/src/role.c#L1131-L1136)), checking for a nonzero `flags.initorientation` (introduced in d71ba77c) simply overrides the hero's sexual orientation with a random one if and only if they are straight. I don't think we even really need to check orientation in `u_init`, since a random orientation has already been selected in `optfn_orientation`(options.c) if the player didn't specify one in the config file, or in `str2orientation`(role.c) if the player specified \`@' or \`*'.

But if we do want to verify the player has gotten their orientation set at this point, checking for a nonzero `initorientation` won't do it properly.

Also I changed a hardcoded `3` in `optfn_orientation` to `NUM_ORIENTATIONS`.