### PR TITLE
Inform players of their orientation on starting a new game

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -775,9 +775,11 @@ boolean new_game; /* false => restoring an old game */
         Sprintf(eos(buf), " %s", align_str(u.ualignbase[A_ORIGINAL]));
     if (new_game || flags.orientation != flags.initorientation)
         Sprintf(eos(buf), " %s", orientations[flags.orientation].adj);
-    if (!g.urole.name.f
+    if ((!g.urole.name.f || !g.urole.name.n)
         && (new_game
-                ? (g.urole.allow & ROLE_GENDMASK) == (ROLE_MALE | ROLE_FEMALE)
+                ? ((g.urole.allow & ROLE_GENDMASK) != (ROLE_MALE)
+                    && (g.urole.allow & ROLE_GENDMASK) != (ROLE_FEMALE)
+                    && (g.urole.allow & ROLE_GENDMASK) != (ROLE_NEUTER))
                 : currentgend != flags.initgend))
         Sprintf(eos(buf), " %s", genders[currentgend].adj);
 

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -773,13 +773,13 @@ boolean new_game; /* false => restoring an old game */
     *buf = '\0';
     if (new_game || u.ualignbase[A_ORIGINAL] != u.ualignbase[A_CURRENT])
         Sprintf(eos(buf), " %s", align_str(u.ualignbase[A_ORIGINAL]));
+    if (new_game || flags.orientation != flags.initorientation)
+        Sprintf(eos(buf), " %s", orientations[flags.orientation].adj);
     if (!g.urole.name.f
         && (new_game
                 ? (g.urole.allow & ROLE_GENDMASK) == (ROLE_MALE | ROLE_FEMALE)
                 : currentgend != flags.initgend))
         Sprintf(eos(buf), " %s", genders[currentgend].adj);
-    if (new_game || flags.orientation != flags.initorientation)
-        Sprintf(eos(buf), " %s", orientations[flags.orientation].adj);
 
     pline(new_game ? "%s %s, welcome to SpliceHack!  You are a%s %s %s."
                    : "%s %s, the%s %s %s, welcome back to SpliceHack!",

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -778,6 +778,8 @@ boolean new_game; /* false => restoring an old game */
                 ? (g.urole.allow & ROLE_GENDMASK) == (ROLE_MALE | ROLE_FEMALE)
                 : currentgend != flags.initgend))
         Sprintf(eos(buf), " %s", genders[currentgend].adj);
+    if (new_game || flags.orientation != flags.initorientation)
+        Sprintf(eos(buf), " %s", orientations[flags.orientation].adj);
 
     pline(new_game ? "%s %s, welcome to SpliceHack!  You are a%s %s %s."
                    : "%s %s, the%s %s %s, welcome back to SpliceHack!",


### PR DESCRIPTION
Because sexual orientation can be randomized if not specified, I think it's good to give players an idea of what to expect. Being told their orientation will potentially reduce confusion about foocubi encounters not working as expected in vanilla NetHack.