### PR TITLE
Fix Amulet of Change

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -830,9 +830,9 @@ Amulet_on()
         /* Don't use same message as polymorph */
         if (orig_sex != poly_gender()) {
             makeknown(AMULET_OF_CHANGE);
-            You("are suddenly very %s! (%d)",
+            You("are suddenly very %s!",
                 poly_gender() == GEND_F ? "feminine" 
-                    : (poly_gender() == GEND_M ? "masculine" : "androgynous"), flags.gender);
+                    : (poly_gender() == GEND_M ? "masculine" : "androgynous"));
             g.context.botl = 1;
         } else
             /* already polymorphed into single-gender monster; only

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -831,7 +831,8 @@ Amulet_on()
         if (orig_sex != poly_gender()) {
             makeknown(AMULET_OF_CHANGE);
             You("are suddenly very %s!",
-                flags.gender ? "feminine" : "masculine");
+                flags.gender == GEND_F ? "feminine" 
+                    : (flags.gender == GEND_M ? "masculine" : "androgynous"));
             g.context.botl = 1;
         } else
             /* already polymorphed into single-gender monster; only

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -830,9 +830,9 @@ Amulet_on()
         /* Don't use same message as polymorph */
         if (orig_sex != poly_gender()) {
             makeknown(AMULET_OF_CHANGE);
-            You("are suddenly very %s!",
-                flags.gender == GEND_F ? "feminine" 
-                    : (flags.gender == GEND_M ? "masculine" : "androgynous"));
+            You("are suddenly very %s! (%d)",
+                poly_gender() == GEND_F ? "feminine" 
+                    : (poly_gender() == GEND_M ? "masculine" : "androgynous"), flags.gender);
             g.context.botl = 1;
         } else
             /* already polymorphed into single-gender monster; only

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -242,6 +242,7 @@ change_sex()
     /* setting u.umonster for caveman/cavewoman or priest/priestess
        swap unintentionally makes `Upolyd' appear to be true */
     boolean already_polyd = (boolean) Upolyd;
+    int newgender;
 
     /* Some monsters are always of one sex and their sex can't be changed;
      * Succubi/incubi can change, but are handled below.
@@ -249,12 +250,17 @@ change_sex()
      * !already_polyd check necessary because is_male() and is_female()
      * are true if the player is a priest/priestess.
      */
+
+    /* Select gender from the list at random excluding the starting gender */
+    newgender = GEND_M + (poly_gender() + rn2(ROLE_GENDERS - 1) + 1) % ROLE_GENDERS;
+
     if (!already_polyd
         || (!is_male(g.youmonst.data) && !is_female(g.youmonst.data)
             && !is_neuter(g.youmonst.data)))
-        flags.gender = (flags.gender == ROLE_GENDERS-1) ? 0 : flags.gender + 1;
+        flags.gender = newgender;
     if (already_polyd) /* poly'd: also change saved sex */
-        u.ugender = (u.ugender == ROLE_GENDERS-1) ? 0 : u.ugender + 1;
+        u.ugender = newgender;
+
     max_rank_sz(); /* [this appears to be superfluous] */
     if ((already_polyd ? u.ugender : flags.gender == GEND_F) && g.urole.name.f)
         Strcpy(g.pl_character, g.urole.name.f);

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -252,9 +252,9 @@ change_sex()
     if (!already_polyd
         || (!is_male(g.youmonst.data) && !is_female(g.youmonst.data)
             && !is_neuter(g.youmonst.data)))
-        flags.gender = !flags.gender;
+        flags.gender = (flags.gender == ROLE_GENDERS-1) ? 0 : flags.gender + 1;
     if (already_polyd) /* poly'd: also change saved sex */
-        u.ugender = !u.ugender;
+        u.ugender = (u.ugender == ROLE_GENDERS-1) ? 0 : u.ugender + 1;
     max_rank_sz(); /* [this appears to be superfluous] */
     if ((already_polyd ? u.ugender : flags.gender == GEND_F) && g.urole.name.f)
         Strcpy(g.pl_character, g.urole.name.f);

--- a/src/role.c
+++ b/src/role.c
@@ -2448,9 +2448,8 @@ role_init()
 
     /* Check for a valid gender.  If new game, check both initgend
      * and female.  On restore, assume flags.gender is correct. */
-    flags.gender = flags.initgend;
-
     if (flags.pantheon == -1) { /* new game */
+        flags.gender = flags.initgend;
         if (!validgend(flags.initrole, flags.initrace, flags.gender))
             flags.gender = !flags.gender;
     }


### PR DESCRIPTION
Amulet of change will now ~cycle through all possible genders in order (m -> f -> n -> m ...)~ choose a gender at random from between `GEND_M` and `GEND_M + (ROLE_GENDERS-1)` rather than just switching between male and female -- previously if a nonbinary character wore an amulet of change it was impossible for them to return to their original gender.

Also fixed a bug that caused character gender to reset after every save/reload, which obviously broke the amulet of change in a significant way.