### PR TITLE
Add material interactions when forcing a lock

### DIFF
--- a/include/decl.h
+++ b/include/decl.h
@@ -299,6 +299,7 @@ E const struct c_common_strings c_common_strings;
 
 /* material strings */
 E const char *materialnm[];
+E const int matdur[];
 
 /* empty string that is non-const for parameter use */
 E char emptystr[];

--- a/src/decl.c
+++ b/src/decl.c
@@ -110,6 +110,34 @@ const char *materialnm[] = { "mysterious", "liquid",  "wax",        "organic",
                              "plastic",    "glass",   "crystal",   "shadowspun",
                              "stone" };
 
+const int matdur[] = {
+    0,
+    1,  // LIQUID
+    1,  // WAX
+    1,  // VEGGY
+    3,  // FLESH
+    1,  // PAPER
+    2,  // CLOTH
+    3,  // LEATHER
+    4,  // WOOD
+    3,  // BONE
+    9,  // DRAGON_HIDE
+    7,  // IRON - de facto baseline for metal armor
+    7,  // METAL
+    5,  // COPPER
+    5,  // SILVER
+    4,  // GOLD
+    6,  // PLATINUM
+    8,  // ADAMANTINE
+    7,  // COLD IRON
+    8,  // MITHRIL
+    3,  // PLASTIC
+    2,  // GLASS
+    5,  // GEMSTONE
+    7,  // SHADOW
+    6,  // MINERAL
+};
+
 char emptystr[] = {0};       /* non-const */
 
 /* Global windowing data, defined here for multi-window-system support */

--- a/src/decl.c
+++ b/src/decl.c
@@ -112,30 +112,30 @@ const char *materialnm[] = { "mysterious", "liquid",  "wax",        "organic",
 
 const int matdur[] = {
     0,
-    1,  // LIQUID
-    1,  // WAX
-    1,  // VEGGY
-    3,  // FLESH
-    1,  // PAPER
-    2,  // CLOTH
-    3,  // LEATHER
-    4,  // WOOD
-    3,  // BONE
-    9,  // DRAGON_HIDE
-    7,  // IRON - de facto baseline for metal armor
-    7,  // METAL
-    5,  // COPPER
-    5,  // SILVER
-    4,  // GOLD
-    6,  // PLATINUM
-    8,  // ADAMANTINE
-    7,  // COLD IRON
-    8,  // MITHRIL
-    3,  // PLASTIC
-    2,  // GLASS
-    5,  // GEMSTONE
-    7,  // SHADOW
-    6,  // MINERAL
+    1,  /* LIQUID */
+    1,  /* WAX */
+    1,  /* VEGGY */
+    3,  /* FLESH */
+    1,  /* PAPER */
+    2,  /* CLOTH */
+    3,  /* LEATHER */
+    4,  /* WOOD */
+    3,  /* BONE */
+    9,  /* DRAGON_HIDE */
+    7,  /* IRON */
+    7,  /* METAL */
+    5,  /* COPPER */
+    5,  /* SILVER */
+    4,  /* GOLD */
+    6,  /* PLATINUM */
+    8,  /* ADAMANTINE */
+    7,  /* COLD IRON */
+    8,  /* MITHRIL */
+    3,  /* PLASTIC */
+    2,  /* GLASS */
+    5,  /* GEMSTONE */
+    7,  /* SHADOW */
+    6,  /* MINERAL */
 };
 
 char emptystr[] = {0};       /* non-const */

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -636,7 +636,11 @@ xchar x, y;
             pline("THUD!");
         container_impact_dmg(g.kickedobj, x, y);
         if (g.kickedobj->olocked) {
-            if (!rn2(5) || (martial() && !rn2(2))) {
+            float lockdur, lockdur_ratio;
+            lockdur = matdur[g.kickedobj->material];
+            lockdur_ratio = lockdur / matdur[objects[g.kickedobj->otyp].oc_material];
+
+            if (!rn2((int) 5 * lockdur_ratio) || (martial() && !rn2((int) 2 * lockdur_ratio))) {
                 You("break open the lock!");
                 breakchestlock(g.kickedobj, FALSE);
                 if (otrp)

--- a/src/lock.c
+++ b/src/lock.c
@@ -210,37 +210,6 @@ boolean destroyit;
     }
 }
 
-/* Relative durability (likelihood of withstanding damage intact) of various
- * materials. */
-static
-const int matdur[] = {
-     0,
-     1,  // LIQUID
-     1,  // WAX
-     1,  // VEGGY
-     3,  // FLESH
-     1,  // PAPER
-     2,  // CLOTH
-     3,  // LEATHER
-     4,  // WOOD
-     3,  // BONE
-     9,  // DRAGON_HIDE
-     7,  // IRON - de facto baseline for metal armor
-     7,  // METAL
-     5,  // COPPER
-     5,  // SILVER
-     4,  // GOLD
-     6,  // PLATINUM
-     8,  // ADAMANTINE
-     7,  // COLD IRON
-     8,  // MITHRIL
-     3,  // PLASTIC
-     2,  // GLASS
-     5,  // GEMSTONE
-     7,  // SHADOW
-     6,  // MINERAL
-};
-
 /* try to force a locked chest */
 static int
 forcelock(VOID_ARGS)

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -1472,31 +1472,31 @@ register struct obj *otmp;
  * Instead, use arbitrary units. */
 static
 const int matdensities[] = {
-    0,   // will cause div/0 errors if anything is this material
-    10,  // LIQUID
-    15,  // WAX
-    10,  // VEGGY
-    10,  // FLESH
-    5,   // PAPER
-    10,  // CLOTH
-    15,  // LEATHER
-    30,  // WOOD
-    25,  // BONE
-    20,  // DRAGONHIDE
-    80,  // IRON
-    70,  // METAL
-    85,  // COPPER
-    90,  // SILVER
-   120, /* GOLD */
-   120, /* PLATINUM */
-    60,  // ADAMANTINE
-    80,  // COLD IRON
-    50, /* MITHRIL */
-    20,  // PLASTIC
-    60,  // GLASS
-    55,  // GEMSTONE
-     1,  // SHADOW
-    70,  // MINERAL
+    0,   /* will cause div/0 errors if anything is this material */
+    10,  /* LIQUID */
+    15,  /* WAX */
+    10,  /* VEGGY */
+    10,  /* FLESH */
+    5,   /* PAPER */
+    10,  /* CLOTH */
+    15,  /* LEATHER */
+    30,  /* WOOD */
+    25,  /* BONE */
+    20,  /* DRAGONHIDE */
+    80,  /* IRON */
+    70,  /* METAL */
+    85,  /* COPPER */
+    90,  /* SILVER */
+   120,  /* GOLD */
+   120,  /* PLATINUM */
+    60,  /* ADAMANTINE */
+    80,  /* COLD IRON */
+    50,  /* MITHRIL */
+    20,  /* PLASTIC */
+    60,  /* GLASS */
+    55,  /* GEMSTONE */
+     1,  /* SHADOW */
+    70,  /* MINERAL */
 };
 
 
@@ -1598,30 +1598,30 @@ register struct obj *obj;
  * matters.) */
 const int matac[] = {
      0,
-     0,  // LIQUID
-     1,  // WAX
-     1,  // VEGGY
-     3,  // FLESH
-     1,  // PAPER
-     2,  // CLOTH
-     3,  // LEATHER
-     4,  // WOOD
-     4,  // BONE
-     10, // DRAGON_HIDE
-     5,  // IRON - de facto baseline for metal armor
-     5,  // METAL
-     4,  // COPPER
-     5,  // SILVER
-     3,  // GOLD
-     4,  // PLATINUM
-     7,  // ADAMANTINE
-     5,  // COLD IRON
-     6,  // MITHRIL
-     3,  // PLASTIC
-     5,  // GLASS
-     7,  // GEMSTONE
-     5,  // SHADOW
-     6,  // MINERAL
+     0,  /* LIQUID */
+     1,  /* WAX */
+     1,  /* VEGGY */
+     3,  /* FLESH */
+     1,  /* PAPER */
+     2,  /* CLOTH */
+     3,  /* LEATHER */
+     4,  /* WOOD */
+     4,  /* BONE */
+     10, /* DRAGON_HIDE */
+     5,  /* IRON - de facto baseline for metal armor */
+     5,  /* METAL */
+     4,  /* COPPER */
+     5,  /* SILVER */
+     3,  /* GOLD */
+     4,  /* PLATINUM */
+     7,  /* ADAMANTINE */
+     5,  /* COLD IRON */
+     6,  /* MITHRIL */
+     3,  /* PLASTIC */
+     5,  /* GLASS */
+     7,  /* GEMSTONE */
+     5,  /* SHADOW */
+     6,  /* MINERAL */
 };
 
 /* Compute the bonus or penalty to AC an armor piece should get for being a


### PR DESCRIPTION
A disparity between strengths of the materials of a target box and the weapon used for prying open a lock will now affect the chances of the weapon breaking. Likewise, the comparitive strength of the box material (vs the base material of the container) will have an impact on the chances of the box itself shattering when attacked with a blunt weapon. This will also affect the chance of breaking the box lock open when kicking it.

I originally wrote this code a while ago and the actual durability values and breakage chance formulae may need improvement, or at least review and playtesting.