### PR TITLE
Fix monster card pluralization

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -2465,7 +2465,8 @@ char *str;
           " versus ", " from ",    " in ",
           " on ",     " a la ",    " with", /* " with "? */
           " de ",     " d'",       " du ",
-          "-in-",     "-at-",      0
+          "-in-",     "-at-",      " - ",
+          0
         }, /* list of first characters for all compounds[] entries */
         compound_start[] = " -";
 


### PR DESCRIPTION
Cartomancer "monster cards" were being pluralized like "2 monster card - jackals" instead of "2 monster cards - jackal".

Note that this change will cause problems if there are any other objects written like "foo - bar" that *should* be pluralized as "foo - bars", but I assume that's not the case.