### PR TITLE
Bugfix: impossible called for 0-nutrition foods

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -3842,7 +3842,6 @@ int amt;
         if (obj == g.context.victual.piece) /* always true unless wishing... */
             g.context.victual.reqtime =
                 g.context.victual.usedtime; /* no bites left */
-        obj->oeaten = 1; /* smallest possible positive value */
     }
 }
 


### PR DESCRIPTION
Partly-eaten wraith corpses (which can only be wished for) and
partly-eaten pills (which can happen normally when cursed) caused
an impossible.
"partly eaten food (1) more nutritious than untouched food (0)"

Closes #133