### PR TITLE
Fix corridor generation again

### DIFF
--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -2454,11 +2454,9 @@ dig_corridor(
 
         crm = &levl[xx][yy];
         if (crm->typ == btyp) {
-            if (ftyp != CORR || rn2(100)) {
-                crm->typ = ftyp;
-                if (nxcor && !rn2(50))
-                    (void) mksobj_at(BOULDER, xx, yy, TRUE, FALSE);
-            }
+            crm->typ = ftyp;
+            if (nxcor && !rn2(50))
+                (void) mksobj_at(BOULDER, xx, yy, TRUE, FALSE);
         } else if (crm->typ != ftyp && crm->typ != SCORR) {
             /* strange ... */
             return FALSE;


### PR DESCRIPTION
Secret corridors were (correctly) gone, but the level builder was occasionally leaving
gaps in regular corridors.