### PR TITLE
Fix: Reduce move points given to fleeing monster

### DIFF
--- a/src/monmove.c
+++ b/src/monmove.c
@@ -369,7 +369,7 @@ monflee(
             } else
                 pline("%s turns to flee.", Monnam(mtmp));
         }
-        mtmp->movement += NORMAL_SPEED;
+        mtmp->movement += SLOW_SPEED;
         mtmp->mflee = 1;
     }
     /* ignore recently-stepped spaces when made to flee */


### PR DESCRIPTION
This is a conservative way to tone down infinite fleeing loops. Behavior could be changed instead of a number tweak.

An infinite loop was caused by a monster using 12 movement points to flee, being unable to go anywhere, and then spending those 12 movement points to begin fleeing again.

Fixes #150