### PR TITLE
Fix Gugnir typo

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -2494,9 +2494,8 @@ ground slam
 
 	This technique is considered a finisher for the chained blitz
 	techique. Motion: D,D,D,D
-gugnir
-	The spear used by Odin. When thrown by the hands of a Valkyrie,
-	it will return to the wielder.
+gungnir
+	The spear used by Odin. It rarely, if ever, misses its target.
 gunyoki
 	The samurai's last meal before battle.  It was usually made
 	up of cooked chestnuts, dried seaweed, and sake.

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -146,8 +146,7 @@ static NEARDATA struct artifact artilist[] = {
       NO_DFNS, NO_CARY, 0, A_NONE, NON_PM, NON_PM, 1700L, NO_COLOR),
 
     /*
-    *      Gugnir also returns to the hand of the wielder when thrown if
-    *      the wielder is a Valkyrie, but there is no strength requirement.
+    *      Gugnir has an incredible to-hit.
     */
     A("Gungnir", DWARVISH_SPEAR, (SPFX_RESTR), 0, 0, PHYS(100, 4),
       NO_DFNS, NO_CARY, LIGHTNING_BOLT, A_NEUTRAL, PM_VALKYRIE, NON_PM, 4000L, NO_COLOR),


### PR DESCRIPTION
Somehow, in the process of making literally just these two changes, I managed to repeatedly break my SpliceHack. I'm still not sure what happened, but apparently something about file perms went wonky because it couldn't read the record file when trying to run after building. I have genuinely no clue what caused that, since it didn't seem to be a line ending error (notepad++ tells me there's only LF, no CR, in dat/data.base) and it wasn't a line width error or something so I'm just totally at a loss.

If anybody is curious, it managed to break badly enough that even after `git reset --hard` and rebuilding, it would STILL refuse to launch.

Oh, I also fixed the typo and updated the description.

Fixes #153.