### PR TITLE
Fix: always-fleeing monsters getting +9 movement

### DIFF
--- a/src/monmove.c
+++ b/src/monmove.c
@@ -366,10 +366,12 @@ monflee(
                           Monnam(mtmp), bare_artifactname(uwep));
                 else
                     verbalize("Bright light!");
-            } else
+            } else {
                 pline("%s turns to flee.", Monnam(mtmp));
+                if (mtmp->data->mlet != S_NYMPH)
+                    mtmp->movement += SLOW_SPEED;
+            }
         }
-        mtmp->movement += SLOW_SPEED;
         mtmp->mflee = 1;
     }
     /* ignore recently-stepped spaces when made to flee */


### PR DESCRIPTION
Now, the movement bonus should only be given to creatures that "turn to flee"
in combat. Just in case, we exclude nymphs from that bonus, because they were
being ludicrously uncatchable.