### PR TITLE
Add weight display to inventory in non-wizmode

### DIFF
--- a/include/flag.h
+++ b/include/flag.h
@@ -39,6 +39,7 @@ struct flag {
     boolean implicit_uncursed; /* maybe omit "uncursed" status in inventory */
     boolean ins_chkpt;       /* checkpoint as appropriate; INSURANCE */
     boolean invlet_constant; /* let objects keep their inventory symbol */
+    boolean invweight;       /* show item weights in inventory */
     boolean legacy;          /* print game entry "story" */
     boolean lit_corridor;    /* show a dark corr as lit if it is in sight */
     boolean mention_decor;   /* give feedback for unobscured furniture */
@@ -314,7 +315,6 @@ struct instance_flags {
     boolean cmdassist;       /* provide detailed assistance for some comnds */
     boolean fireassist;      /* autowield launcher when using fire-command */
     boolean time_botl;       /* context.botl for 'time' (moves) only */
-    boolean wizweight;       /* display weight of everything in wizard mode */
     boolean wizmgender;      /* test gender info from core in window port */
     boolean msg_is_alert;    /* suggest windowport should grab player's attention
                               * and request <TAB> acknowlegement */

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -251,10 +251,8 @@ opt_##a,
 #endif
     NHOPTB(implicit_uncursed, 0, opt_out, set_in_game, On, Yes, No, No,
                 NoAlias, &flags.implicit_uncursed)
-#if 0   /* obsolete - pre-OSX Mac */
-    NHOPTB(large_font, 0, opt_in, set_in_config, Off, Yes, No, No, NoAlias,
-                &iflags.obsolete)
-#endif
+    NHOPTB(invweight, 0, opt_out, set_in_game, On, Yes, No, No,
+                NoAlias, &flags.invweight)
     NHOPTB(legacy, 0, opt_out, set_in_config, On, Yes, No, No, NoAlias,
                 &flags.legacy)
     NHOPTB(lit_corridor, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,
@@ -576,8 +574,6 @@ opt_##a,
                 NoAlias, "windowing system to use (should be specified first)")
     NHOPTB(wizmgender, 0, opt_in, set_wizonly, Off, Yes, No, No, NoAlias,
                 &iflags.wizmgender)
-    NHOPTB(wizweight, 0, opt_in, set_wizonly, Off, Yes, No, No, NoAlias,
-                &iflags.wizweight)
     NHOPTB(wraptext, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,
                 &iflags.wc2_wraptext)
 

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1466,7 +1466,7 @@ doname_base(struct obj* obj, unsigned int doname_flags)
 
     /* show weight for items (debug tourist info);
        "aum" is stolen from Crawl's "Arbitrary Unit of Measure" */
-    if (wizard && iflags.wizweight) {
+    if (flags.invweight && (obj->where == OBJ_INVENT || wizard)) {
         /* wizard mode user has asked to see object weights */
         if (with_price && (*(eos(bp)-1) == ')'))
             Sprintf(eos(bp)-1, ", %u aum)", obj->owt);


### PR DESCRIPTION
Moves option from `iflags.wizweight` to `flags.invweight`. Boolean, defaults to true.