### PR TITLE
Block varying murder messages in June

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -274,11 +274,6 @@
 #endif
 #endif
 
-
-/* If UNIQDEATHS is defined, "killed by" will sometimes be replaced by a random
-   selection of unique messages. This can be commented out for tournament play. */
-#define UNIQDEATHS
-
 /*
  *      If COMPRESS is defined, it should contain the full path name of your
  *      'compress' program.

--- a/include/extern.h
+++ b/include/extern.h
@@ -992,6 +992,7 @@ extern long hhmmss(time_t);
 extern char *yyyymmddhhmmss(time_t);
 extern time_t time_from_yyyymmddhhmmss(char *);
 extern int phase_of_the_moon(void);
+extern boolean is_june(void);
 extern boolean friday_13th(void);
 extern boolean pi_day(void);
 extern boolean mayfourth(void);

--- a/include/flag.h
+++ b/include/flag.h
@@ -245,6 +245,7 @@ struct instance_flags {
     boolean echo;             /* 1 to echo characters */
     boolean force_invmenu;    /* always menu when handling inventory */
     boolean hilite_pile;      /* mark piles of objects with a hilite */
+    boolean killedby;         /* always print 'killed by' when murdered */
     boolean menu_head_objsym; /* Show obj symbol in menu headings */
     boolean menu_overlay;     /* Draw menus over the map */
     boolean menu_requested;   /* Flag for overloaded use of 'm' prefix

--- a/include/optlist.h
+++ b/include/optlist.h
@@ -255,6 +255,8 @@ opt_##a,
     NHOPTB(large_font, 0, opt_in, set_in_config, Off, Yes, No, No, NoAlias,
                 &iflags.obsolete)
 #endif
+    NHOPTB(killedby, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,
+                &iflags.killedby)
     NHOPTB(legacy, 0, opt_out, set_in_config, On, Yes, No, No, NoAlias,
                 &flags.legacy)
     NHOPTB(lit_corridor, 0, opt_in, set_in_game, Off, Yes, No, No, NoAlias,

--- a/src/hacklib.c
+++ b/src/hacklib.c
@@ -1130,6 +1130,14 @@ phase_of_the_moon(void) /* 0-7, with 0: new, 4: full */
 }
 
 boolean
+is_june(void)
+{
+    register int month = getlt()->tm_mon;
+
+    return (boolean) (month == 5); // 0 is Jan, 11 is Dec
+}
+
+boolean
 friday_13th(void)
 {
     register struct tm *lt = getlt();

--- a/src/topten.c
+++ b/src/topten.c
@@ -124,12 +124,10 @@ formatkiller(
         kname = an(kname);
         /*FALLTHRU*/
     case KILLED_BY:
-        #ifdef UNIQDEATHS
-        if (how == MURDERED)
+        if (how == MURDERED && !is_june() && !(iflags.killedby))
             (void) strncat(buf,
                 murdered_by_msg[g.moves % SIZE(murdered_by_msg)], siz - 1);
         else
-        #endif
             (void) strncat(buf, killed_by_prefix[how], siz - 1);
         l = strlen(buf);
         buf += l, siz -= l;


### PR DESCRIPTION
Blocks the "inhumed by", "brought low by", etc. messages that replace "killed by" occasionally if it is currently June (checked at time of usage, aka when you die). Also add a `killedby` boolean option (settable in game, defaults to false) that will always force a 'killed by' death message when murdered. This has no real purpose but may be desired someday.