### PR TITLE
Fix funky display of 'covered in blood' for some terrain

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -2382,7 +2382,7 @@ map_glyphinfo(xchar x, xchar y, int glyph,
         }
 
         /* blood overrides other colors */
-        if (levl[x][y].splatpm && cansee(x, y)) {
+        if (levl[x][y].splatpm && cansee(x, y) && !(glyph_to_cmap(glyph) == S_cloud || glyph_to_cmap(glyph) == S_poisoncloud)) {
             color = blood_color(levl[x][y].splatpm);
         }
     } else if ((offset = (glyph - GLYPH_OBJ_OFF)) >= 0) { /* object */

--- a/src/pager.c
+++ b/src/pager.c
@@ -467,6 +467,7 @@ lookat(int x, int y, char *buf, char *monbuf)
     struct monst *mtmp = (struct monst *) 0;
     struct permonst *pm = (struct permonst *) 0;
     int glyph;
+    boolean printed_blood = FALSE;
 
     buf[0] = monbuf[0] = '\0';
     glyph = glyph_at(x, y);
@@ -575,9 +576,15 @@ lookat(int x, int y, char *buf, char *monbuf)
         case S_cloud:
             Strcpy(buf,
                    Is_airlevel(&u.uz) ? "cloudy area" : "fog/vapor cloud");
+            printed_blood = TRUE;
+            break;
+        case S_poisoncloud:
+            printed_blood = TRUE;
             break;
         case S_pool:
-            Strcpy(buf, waterbody_name(x, y));
+            Sprintf(eos(buf), (levl[x][y].splatpm) ? "bloody " : "");
+            Sprintf(eos(buf), waterbody_name(x, y));
+            printed_blood = TRUE;
             break;
         case S_stone:
             if (!levl[x][y].seenv) {
@@ -598,7 +605,7 @@ lookat(int x, int y, char *buf, char *monbuf)
             break;
         }
     }
-    if (cansee(x, y) && levl[x][y].splatpm)
+    if (cansee(x, y) && levl[x][y].splatpm && !printed_blood)
         Sprintf(eos(buf), " covered in %s blood",
             pmname(&mons[levl[x][y].splatpm], NEUTRAL));
     return (pm && !Hallucination) ? pm : (struct permonst *) 0;


### PR DESCRIPTION
It's possible more terrain needs to be added to this list, but this is a decent fix for starters. Stops moats with blood from being listed as 'moat covered in newt blood' since that makes no sense - instead, they're 'bloody moats'. Similarly, blood is totally supressed in both messaging and color changing effects from clouds - I'm pretty sure a stinking cloud shouldn't turn red because there's blood underneath it.

Did not check things like air since I'm pretty sure that does nothing, but I'm not sure about other stuff like thrones that might be funky. Who knows.