### PR TITLE
Fix off by one error in killed_by list

### DIFF
--- a/src/topten.c
+++ b/src/topten.c
@@ -94,7 +94,7 @@ formatkiller(
 {
     static NEARDATA const char *const killed_by_prefix[] = {
         /* DIED, MURDERED, TREX, CHOKING, POISONING, STARVING, */
-        "killed by ", "killed by " "choked on ", "tyranosaurus rekt by", "poisoned by ", "died of ",
+        "killed by ", "killed by ", "tyrannosaurus rekt by", "choked on ", "poisoned by ", "died of ",
         /* DROWNING, BURNING, DISSOLVED, CRUSHING, */
         "drowned in ", "burned by ", "dissolved in ", "crushed to death by ",
         /* STONING, TURNED_SLIME, GENOCIDED, */


### PR DESCRIPTION
#165 

Turns out in addition to a missing comma, T-Rex and choking deaths were swapped, so you'd get "tyranosaurus rekt bya lembas wafer" [sic].