### PR TITLE
Don't name levels "pool"

### DIFF
--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -3574,7 +3574,7 @@ static const char *const neutral_adj[] = {
 };
 
 static const char *const fountnames[] = {
-    "Font",     "Pool", "Haven",    "Oasis",
+    "Fountain", "Font", "Haven",    "Oasis",
     "Respite",  "Rest", "Tears",    "Spring",
 };
 


### PR DESCRIPTION
it may cause players to look for a literal pool/moat when there isn't one.