### PR TITLE
Create a top-level symlink to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+doc/changelog.md


### PR DESCRIPTION
Put an all-caps CHANGELOG in the main directory per github convention,
  but also keep changelog.md in the doc/ folder per nethack convention.

This is a relative path symbolic link, and should translate fine across
machines. see: https://mokacoding.com/blog/symliks-in-git/