### PR TITLE
Fix: improve message for weapon familiarity

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1521,7 +1521,7 @@ hmon_hitmon(struct monst *mon,
         && (uwep->oclass == WEAPON_CLASS || is_weptool(uwep)) && !uwep->known) {
         uwep->wep_kills++;
         if (uwep->wep_kills > KILL_FAMILIARITY && !rn2(max(2, uwep->spe) && !uwep->known)) {
-            You("have developed a bond of familiarity with your %s.", 
+            You("have become quite familiar with %s.", 
                 yobjnam(uwep, (char *) 0));
             uwep->known = TRUE;
             update_inventory();


### PR DESCRIPTION
- yobjname contains a "your", so we don't need to write one.
- "bond of familiarity" sounds like the object might be sapient or at least have feelings, which isn't yet true for weapons in Splice.
- mobileus:"You have developed a bond of familiarity with your your mithril runed dagger \ these weapons have feelings!"