### PR TITLE
Tone down amount of item destruction for monks

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -6634,7 +6634,7 @@ skill_hit_effects(struct monst *mon) {
     int damage_bonus = 0;
     /* Martial arts skills */
     if (!uwep && !uarm && !uarms) {
-        if (P_SKILL(P_FLAMING_FISTS) > P_UNSKILLED && rn2(20) < P_SKILL(P_FLAMING_FISTS)) {
+        if (P_SKILL(P_FLAMING_FISTS) > P_UNSKILLED && rn2(25) < P_SKILL(P_FLAMING_FISTS)) {
             if (resists_fire(mon)) {
                 shieldeff(mon->mx, mon->my);
             } else {
@@ -6642,8 +6642,8 @@ skill_hit_effects(struct monst *mon) {
                 damage_bonus += d(1,6);
                 golemeffects(mon, AD_FIRE, damage_bonus);
             }
-            damage_bonus += destroy_mitem(mon, POTION_CLASS, AD_FIRE);
-            ignite_items(mon->minvent);
+	    if (damage_bonus > 4)
+            	damage_bonus += destroy_mitem(mon, SCROLL_CLASS, AD_FIRE);
         }
         if (P_SKILL(P_FREEZING_FISTS) > P_UNSKILLED && rn2(25) < P_SKILL(P_FREEZING_FISTS)) {
             if (resists_cold(mon)) {
@@ -6653,7 +6653,8 @@ skill_hit_effects(struct monst *mon) {
                 damage_bonus += d(1,6);
                 golemeffects(mon, AD_COLD, damage_bonus);
             }
-            damage_bonus += destroy_mitem(mon, POTION_CLASS, AD_COLD);
+	    if (damage_bonus > 4)
+            	damage_bonus += destroy_mitem(mon, POTION_CLASS, AD_COLD);
         }
         if (P_SKILL(P_SHOCKING_FISTS) > P_UNSKILLED && rn2(100) < P_SKILL(P_SHOCKING_FISTS)) {
             if (resists_cold(mon)) {
@@ -6663,7 +6664,8 @@ skill_hit_effects(struct monst *mon) {
                 damage_bonus += d(1,20);
                 golemeffects(mon, AD_ELEC, damage_bonus);
             }
-            damage_bonus += destroy_mitem(mon, WAND_CLASS, AD_ELEC);
+	    if (damage_bonus > 4)
+            	damage_bonus += destroy_mitem(mon, WAND_CLASS, AD_ELEC);
         }
         if (P_SKILL(P_BLOOD_RAGE) > P_UNSKILLED && (u.uhp < (u.uhp / 2))) {
             pline("Your rage strengthens your attack!");


### PR DESCRIPTION
Amateurhour reports a large degree of destruction to loot in monster inventories.

We can change it so that low amounts of elemental damage aren't intense enough to destroy items.

Aosdict has a much more comprehensive patch for limiting itemdest based on amount of damage, or we could just remove itemdest from fist techniques under a basis that skill slot expenditure should generally not be unhelpful? I wouldn't generally trade away a good scroll for 3 points of damage.