### PR TITLE
Fix: don't allow exploders to become explosive

### DIFF
--- a/src/makemon.c
+++ b/src/makemon.c
@@ -3010,6 +3010,8 @@ is_valid_template(struct monst *mtmp, int tindex) {
     case MT_ICY_DRAKKEN:
     case MT_FIERY_DRAKKEN:
         return !is_dragon(mtmp->data);
+    case MT_EXPLOSIVE:
+        return !(mtmp->data->mlet == S_EYE);
     default:
         return TRUE;
     }


### PR DESCRIPTION
(not sure i got the syntax right for this one. i spawned a couple hundred S_EYE monsters and none of them got the explosive template, so it **seems** like this worked but i can't be 100% sure)

It doesn't do anything for a monster to have two detonation attacks; once
the first one happens, the monster is gone, so the added explosion from a
template will never occur.