### PR TITLE
Fix segfault from disenchanter attack

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -3634,7 +3634,7 @@ mhitm_ad_ench(struct monst *magr, struct attack *mattk, struct monst *mdef,
                     break;
                 }
             }
-            if (drain_item(obj, FALSE)) {
+            if (obj && drain_item(obj, FALSE)) {
                 pline("%s less effective.", Yobjnam2(obj, "seem"));
             }
         }


### PR DESCRIPTION
When a disenchanter would hit you, the game would attempt to find some
armour to disenchant, falling back on a roll for an accessory

If no object was selected by that point, the game would dereference null