### PR TITLE
Fix: if monster steed is teleported, take its rider along with it.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -32,6 +32,7 @@
 - Unlocking tools can degrade and break.
 
 ### Small Tweaks / Bugfixes
+- If monster steed is teleported, take its rider along with it.
 - Fixed manticore spikes causing an error when initializing objects.
 - Moved manticore spikes out of the venoms class.
 - Fixed manticore spikes producing error messages when thrown.

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -1282,6 +1282,12 @@ rloc(
         return TRUE;
     }
 
+    if (mtmp->rider_id) {
+        /* teleport rider along with steed */
+        struct monst *rider = get_mon_rider(mtmp);
+        return rloc(rider, suppress_impossible);
+    }
+
     if (mtmp->iswiz && mtmp->mx) { /* Wizard, not just arriving */
         stairway *stway;
 


### PR DESCRIPTION
Might fix some of the "tail of a it" bugs? #172 