### PR TITLE
Spicy healers: self-targeted spells also hit pets

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -2615,6 +2615,13 @@ zapyourself(struct obj *obj, boolean ordinary)
         wonder = TRUE;
         learn_it = TRUE;
     }
+    
+    // A Healer's self-targeted zaps also hit their visible pets
+    struct monst *mtmp;
+    if (Role_if(PM_HEALER))
+        for (mtmp = fmon; mtmp; mtmp = mtmp->nmon)
+            if (mtmp->mtame && canspotmon(mtmp))
+                bhitm(mtmp, obj);
 
     switch (obj->otyp) {
     case WAN_STRIKING:


### PR DESCRIPTION
Applies to spells aimed at self, not ray bounces. Primarily intended for
healing the squad, but no one is enforcing fireball safety regulations.